### PR TITLE
Adds apt layer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,12 @@
 options:
+  install_sources:
+    type: string
+    default: deb http://packages.elastic.co/beats/apt stable main
+    description: apt repository to fetch beats from
+  install_keys:
+    type: string
+    default: D88E42B4
+    description: repository key
   procs:
     type: string
     default: ".*"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,3 +3,5 @@ summary: Deploys topbeat
 maintainer: Charles Butler <charles.butler@canonical.com>
 description: |
   Topbeat is an open source shipper for per-process CPU, memory, and disk usage metrics
+series:
+ - trusty

--- a/reactive/topbeat.py
+++ b/reactive/topbeat.py
@@ -1,9 +1,11 @@
 from charms.reactive import when
 from charms.reactive import when_file_changed
+from charms.reactive import when_any
 from charms.reactive import when_not
 from charms.reactive import set_state
 from charms.reactive import remove_state
 from charms.reactive import is_state
+import charms.apt
 
 from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.host import service_restart
@@ -14,38 +16,37 @@ from elasticbeats import enable_beat_on_boot
 from elasticbeats import push_beat_index
 
 
-@when('beats.repo.available')
-@when_not('topbeat.installed')
+@when_not('apt.installed.topbeat')
 def install_topbeat():
     status_set('maintenance', 'Installing topbeat')
-    apt_install(['topbeat'], fatal=True)
+    charms.apt.queue_install(['topbeat'])
     set_state('topbeat.installed')
     set_state('beat.render')
 
 
 @when('beat.render')
+@when_any('elasticsearch.available', 'logstash.available')
 def render_topbeat_template():
     render_without_context('topbeat.yml', '/etc/topbeat/topbeat.yml')
     remove_state('beat.render')
     status_set('active', 'Topbeat ready')
-    if is_state('elasticsearch.available') or is_state('logstash.available'):
-        service_restart('topbeat')
+    service_restart('topbeat')
 
 
 @when('config.changed.install_sources')
 @when('config.changed.install_keys')
 def reinstall_topbeat():
-    remove_state('topbeat.installed')
+    remove_state('apt.installed.topbeat')
 
 
-@when('topbeat.installed')
+@when('apt.installed.topbeat')
 @when_not('topbeat.autostarted')
 def enlist_topbeat():
     enable_beat_on_boot('topbeat')
     set_state('topbeat.autostarted')
 
 
-@when('topbeat.installed')
+@when('apt.installed.topbeat')
 @when('elasticsearch.available')
 @when_not('topbeat.index.pushed')
 def push_topbeat_index(elasticsearch):


### PR DESCRIPTION
Refactors out some manual management apt packages, related to the
changes in beats-base layer (to remove manual package handling)
https://github.com/juju-solutions/layer-beats-base/issues/4

This also includes series in metdata and forward ports the
apt-layer configuration to ensure it doesn't get lost in the
shuffle.
