### PR TITLE
refresh the topbeat charm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,43 @@
 # Topbeat
 
-A lightweight way to gather CPU, memory, and other per-process and system wide data, then ship it to Elasticsearch to analyze the results.
+A lightweight way to gather CPU, memory, and other per-process and system wide
+data, then ship it to Elasticsearch to analyze the results.
+
 
 ## Usage
 
-Top can be added to any principal charm thanks to the wonders of being
-a subordinate charm. You can simply deploy the 'beats-core' bundle
-which stands up Elasticsearch, Kibana, and the three known working Beats
-subordinate services.
+Topbeat can be added to any principal charm thanks to the wonders of being
+a subordinate charm. The following usage example will deploy an ubuntu
+metric source along with the elk stack so we can visualize our data.
+
+    juju deploy ~containers/bundle/elk-stack
+    juju deploy ~containers/topbeat
+    juju deploy ubuntu
+    juju add-relation topbeat:beats-host ubuntu
+    juju add-relation topbeat logstash
+
+
+### Deploying the minimal Beats formation
+
+If you do not need log buffering and alternate transforms on data that is
+being shipped to ElasticSearch, you can simply deploy the 'beats-core' bundle
+which stands up Elasticsearch, Kibana, and the known working Beats
+subordinate applications.
 
     juju deploy ~containers/bundle/beats-core
     juju deploy ubuntu
+    juju add-relation filebeat:beats-host ubuntu
     juju add-relation topbeat:beats-host ubuntu
 
+### Changing what is shipped
 
-### A note about the beats-host relationship
-
-The Beats suite of charms leverage the implicit "juju-info" relation interface
-which is special and unique in the context of subordinates. This is what allows
-us to relate the beat to any host, but may have some display oddities in the
-juju-gui. Until this is resolved, it's recommended to relate beats to their
-principal services using the CLI
-
-### Changing whats being shipped
-
-by default, the Topbeat charm is setup to ship everything:
+By default, the Topbeat charm is setup to ship everything:
 
     procs: .*
 
 This is a regular expression to match the processes that are monitored
 
-    juju set topbeat procs="^$"
+    juju config topbeat procs="^$"
 
 would tell topbeat not to send any process data and only collect the machine
 statistics such as load, ram, and disk usage.
@@ -38,42 +45,48 @@ statistics such as load, ram, and disk usage.
 
 ## Testing the deployment
 
-The services provide extended status reporting to indicate when they are ready:
+The applications provide extended status reporting to indicate when they are
+ready:
 
-    juju status --format=tabular
+    juju status
 
 This is particularly useful when combined with watch to track the on-going
 progress of the deployment:
 
-    watch -n 0.5 juju status --format=tabular
+    watch juju status
 
 The message for each unit will provide information about that unit's state.
 Once they all indicate that they are ready, you can navigate to the kibana
-url and view the streamed log data from the Ubuntu host.
+url and view the streamed data from the Ubuntu host.
 
     juju status kibana --format=yaml | grep public-address
 
-  open http://&lt;kibana-ip&gt;/ in a browser and begin creating your dashboard
-  visualizations
+Navigate to http://&lt;kibana-ip&gt;/ in a browser and begin creating your
+dashboard visualizations.
+
 
 ## Scale Out Usage with different configuration
 
 Perhaps you want to monitor things slightly differently on only a few charms
 in your model:
 
-    juju deploy ~containers/trusty/topbeat custom-topbeat
+    juju deploy ~containers/topbeat custom-topbeat
     juju add-relation custom-topbeat:elasticsearch elasticsearch
 
-you are then free to relate this subordinate, and configure it for exactly
-how you want the hosts to be monitored, using the existing beats-core infrastructure
-you've stood up in the earlier example.
-
+You are then free to configure and relate custom-topbeat to your host(s) to be
+monitored using the existing beats-core infrastructure you stood up in the
+earlier example.
 
 
 ## Contact information
 
-- Charles Butler &lt;charles.butler@canonical.com&gt;
-- Matt Bruzek &lt;matthew.bruzek@canonical.com&gt;
+- Charles Butler <Chuck@dasroot.net>
+- Matthew Bruzek <mbruzek@ubuntu.com>
+- Tim Van Steenburgh <tim.van.steenburgh@canonical.com>
+- George Kraft <george.kraft@canonical.com>
+- Rye Terrell <rye.terrell@canonical.com>
+- Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
+
 
 # Need Help?
 

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,22 @@ options:
     type: int
     default: 10
     description: how often in seconds to read system-wide and per-process statistics
+  logging_to_syslog:
+    type: boolean
+    description: "Send filebeat logs to syslog https://www.elastic.co/guide/en/beats/filebeat/master/configuration-logging.html#_literal_to_syslog_literal"
+    default: true
+  logstash_hosts:
+    type: string
+    default: ""
+    description: "A comma separated list of logstash output hosts in addition to those from relations."
+  logstash_ssl_cert:
+    type: string
+    default: ""
+    description: "Public SSL certificate data (base64 encoded) for connecting securely to logstash."
+  logstash_ssl_key:
+    type: string
+    default: ""
+    description: "Private SSL key data (base64 encoded) for connecting security to logstash."
   kafka_hosts:
     type: string
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ options:
     description: how often in seconds to read system-wide and per-process statistics
   logging_to_syslog:
     type: boolean
-    description: "Send filebeat logs to syslog https://www.elastic.co/guide/en/beats/filebeat/master/configuration-logging.html#_literal_to_syslog_literal"
+    description: "Send topbeat logs to syslog (https://www.elastic.co/guide/en/beats/topbeat/current/configuration-logging.html)"
     default: true
   logstash_hosts:
     type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,12 @@
 name: topbeat
 summary: Deploys topbeat
-maintainer: Charles Butler <charles.butler@canonical.com>
+maintainers:
+  - Tim Van Steenburgh <tim.van.steenburgh@canonical.com>
+  - George Kraft <george.kraft@canonical.com>
+  - Rye Terrell <rye.terrell@canonical.com>
+  - Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
+  - Charles Butler <Chuck@dasroot.net>
+  - Matthew Bruzek <mbruzek@ubuntu.com>
 description: |
   Topbeat is an open source shipper for per-process CPU, memory, and disk usage metrics
 series:

--- a/reactive/topbeat.py
+++ b/reactive/topbeat.py
@@ -1,36 +1,65 @@
+import charms.apt
 from charms.reactive import when
-from charms.reactive import when_any
 from charms.reactive import when_not
 from charms.reactive import set_state
 from charms.reactive import remove_state
 from charms.reactive import hook
-import charms.apt
+from charms.templating.jinja2 import render
 
-from charmhelpers.core.hookenv import status_set
-from charmhelpers.core.host import service_restart, service_stop
+from charmhelpers.core.hookenv import config, status_set
+from charmhelpers.core.host import restart_on_change, service_stop
 
 from elasticbeats import render_without_context
 from elasticbeats import enable_beat_on_boot
 from elasticbeats import push_beat_index
 
+import base64
 import os
+
+
+LOGSTASH_SSL_CERT = '/etc/ssl/certs/topbeat-logstash.crt'
+LOGSTASH_SSL_KEY = '/etc/ssl/private/topbeat-logstash.key'
 
 
 @when_not('apt.installed.topbeat')
 def install_topbeat():
     status_set('maintenance', 'Installing topbeat.')
     charms.apt.queue_install(['topbeat'])
-    set_state('topbeat.installed')
-    set_state('beat.render')
 
 
 @when('beat.render')
-@when_any('elasticsearch.available', 'logstash.available', 'kafka.ready')
+@when('apt.installed.topbeat')
+@restart_on_change({
+    '/etc/topbeat/topbeat.yml': ['topbeat']
+    })
 def render_topbeat_template():
-    render_without_context('topbeat.yml', '/etc/topbeat/topbeat.yml')
+    connections = render_without_context('topbeat.yml', '/etc/topbeat/topbeat.yml')
     remove_state('beat.render')
-    status_set('active', 'Topbeat ready.')
-    service_restart('topbeat')
+    if connections:
+        status_set('active', 'Topbeat ready.')
+
+
+@when('beat.render')
+@when('apt.installed.topbeat')
+@restart_on_change({
+    LOGSTASH_SSL_CERT: ['topbeat'],
+    LOGSTASH_SSL_KEY: ['topbeat'],
+    })
+def render_topbeat_logstash_ssl_cert():
+    logstash_ssl_cert = config().get('logstash_ssl_cert')
+    logstash_ssl_key = config().get('logstash_ssl_key')
+    if logstash_ssl_cert and logstash_ssl_key:
+        render(template='{{ data }}',
+               context={'data': base64.b64decode(logstash_ssl_cert)},
+               target=LOGSTASH_SSL_CERT, perms=0o444)
+        render(template='{{ data }}',
+               context={'data': base64.b64decode(logstash_ssl_key)},
+               target=LOGSTASH_SSL_KEY, perms=0o400)
+    else:
+        if not logstash_ssl_cert and os.path.exists(LOGSTASH_SSL_CERT):
+            os.remove(LOGSTASH_SSL_CERT)
+        if not logstash_ssl_key and os.path.exists(LOGSTASH_SSL_KEY):
+            os.remove(LOGSTASH_SSL_KEY)
 
 
 @when('config.changed.install_sources')

--- a/templates/topbeat.yml
+++ b/templates/topbeat.yml
@@ -2,34 +2,67 @@
 input:
   period: {{ period }}
   procs: ["{{ procs }}"]
-{% if not logstash %}
-  {% if elasticsearch %}
+
+logging:
+  {% if logging_to_syslog %}
+  to_syslog: true
+  {% else %}
+  to_syslog: false
+  {% endif %}
+
 output:
-  elasticsearch:
-    hosts: {{ elasticsearch }}
-    {% endif %}
-{% else %}
-output:
+{% if logstash or logstash_hosts %}
   logstash:
     hosts:
-    {% for host in logstash -%}
+      {% if logstash -%}
+      {% for host in logstash -%}
       - "{{ host }}"
-    {% endfor -%}
+      {% endfor %}
+      {%- endif %}
+      {% if logstash_hosts -%}
+      {% for host in logstash_hosts.split(',') -%}
+      - "{{ host|trim }}"
+      {% endfor %}
+      {%- endif %}
+    worker: 1
+    compression_level: 3
+    loadbalance: true
+    {% if logstash_ssl_cert and logstash_ssl_key %}
+    ssl.certificate_authorities: ["/etc/ssl/certs/topbeat-logstash.crt"]
+    ssl.certificate: "/etc/ssl/certs/topbeat-logstash.crt"
+    ssl.key: "/etc/ssl/private/topbeat-logstash.key"
+    {% endif %}
+{% endif %}
+{% if elasticsearch %}
+  elasticsearch:
+    hosts:
+      {% for host in elasticsearch -%}
+      - "{{ host }}"
+      {% endfor %}
+    worker: 1
+    max_retries: 3
+    bulk_max_size: 50
+    timeout: 30
 {% endif %}
 {% if kafka or kafka_hosts%}
   kafka:
     hosts:
+      {% if kafka %}
       {% for host in kafka -%}
       - "{{ host }}"
       {% endfor %}
+      {%- endif %}
       {%- if kafka_hosts -%}
       {% for host in kafka_hosts.split(',') -%}
       - "{{ host|trim }}"
-      {% endfor %}
-      {% endif %}
+      {% endfor -%}
+      {%- endif %}
     topic: "{{kafka_topic}}"
-{% endif %}
+    {%- if kafka_topics %}
+    topics:
+{{kafka_topics|indent(width=6, indentfirst=true)}}
+    {% endif %}
+{% endif -%}
 {% if principal_unit %}
-shipper:
-  name: {{ principal_unit }}
+name: {{ principal_unit }}
 {% endif %}

--- a/tests/10-deploy
+++ b/tests/10-deploy
@@ -7,9 +7,9 @@ import time
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.d = amulet.Deployment(series='trusty')
-        self.d.add('ubuntu', 'cs:trusty/ubuntu')
-        self.d.add('elasticsearch', 'cs:trusty/elasticsearch-14')
+        self.d = amulet.Deployment(series='xenial')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
+        self.d.add('elasticsearch', 'cs:xenial/elasticsearch-25')
         self.d.add('topbeat')
         self.d.relate('topbeat:beats-host', 'ubuntu:juju-info')
         self.d.relate('topbeat:elasticsearch', 'elasticsearch:client')
@@ -36,6 +36,7 @@ class TestCharm(unittest.TestCase):
         config = self.topbeat.file_contents('/etc/topbeat/topbeat.yml')
         self.assertTrue('^$' in config)
         self.assertTrue('187' in config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/20-deploy-with-kafka
+++ b/tests/20-deploy-with-kafka
@@ -2,15 +2,14 @@
 
 import amulet
 import unittest
-import time
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.d = amulet.Deployment(series='trusty')
-        self.d.add('ubuntu', 'cs:trusty/ubuntu')
-        self.d.add('kafka', 'cs:trusty/kafka')
-        self.d.add('zookeeper', 'cs:trusty/zookeeper')
+        self.d = amulet.Deployment(series='xenial')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
+        self.d.add('kafka', 'cs:xenial/kafka')
+        self.d.add('zookeeper', 'cs:xenial/zookeeper')
         self.d.add('topbeat')
         self.d.relate('kafka', 'zookeeper')
         self.d.relate('topbeat:beats-host', 'ubuntu:juju-info')
@@ -26,6 +25,7 @@ class TestCharm(unittest.TestCase):
         kafka_address = self.elasticsearch.relation('client', 'topbeat:kafka')['private-address']  # noqa
         config = self.topbeat.file_contents('/etc/topbeat/topbeat.yml')
         self.assertTrue(kafka_address in config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/30-deploy-with-kafka-hosts
+++ b/tests/30-deploy-with-kafka-hosts
@@ -8,7 +8,7 @@ class TestCharm(unittest.TestCase):
     def setUp(self):
         self.kafka_host = '192.168.0.1:5044'
         self.d = amulet.Deployment(series='xenial')
-        self.d.add('ubuntu', 'cs:ubuntu')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
         self.d.add('topbeat')
         self.d.relate('topbeat:beats-host', 'ubuntu:juju-info')
         self.d.configure('topbeat', {'kafka_hosts': self.kafka_host})
@@ -21,6 +21,7 @@ class TestCharm(unittest.TestCase):
     def test_kafka_host_in_templating(self):
         config = self.topbeat.file_contents('/etc/topbeat/topbeat.yml')
         self.assertTrue(self.kafka_host in config)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- update readme with current juju language; sync it with the filebeat vibe
- support new logstash config opts
- update maintainers
- update template to handle logstash/ES/kafka output
- update tests to use xenial charm revs

This is in the edge channel at rev 8:

https://jujucharms.com/topbeat/8

**Note**: this will likely be the last `topbeat` release, as upstream has renamed this to `metricbeat`. A new metricbeat charm should replace this soon(ish).