### PR TITLE
fix kafka amulet test

### DIFF
--- a/tests/20-deploy-with-kafka
+++ b/tests/20-deploy-with-kafka
@@ -13,16 +13,16 @@ class TestCharm(unittest.TestCase):
         self.d.add('topbeat')
         self.d.relate('kafka', 'zookeeper')
         self.d.relate('topbeat:beats-host', 'ubuntu:juju-info')
-        self.d.relate('topbeat:elasticsearch', 'elasticsearch:client')
+        self.d.relate('topbeat:kafka', 'kafka:client')
 
         self.d.setup(timeout=1200)
         self.d.sentry.wait()
 
-        self.elasticsearch = self.d.sentry['kafka'][0]
+        self.kafka = self.d.sentry['kafka'][0]
         self.topbeat = self.d.sentry['topbeat'][0]
 
     def test_kafka_host_in_templating(self):
-        kafka_address = self.elasticsearch.relation('client', 'topbeat:kafka')['private-address']  # noqa
+        kafka_address = self.kafka.relation('client', 'topbeat:kafka')['private-address']  # noqa
         config = self.topbeat.file_contents('/etc/topbeat/topbeat.yml')
         self.assertTrue(kafka_address in config)
 


### PR DESCRIPTION
The topbeat kafka amulet test was referring to 'elasticsearch'. It should be looking at 'kafka' for this test.